### PR TITLE
feat: translate site from English to German

### DIFF
--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -5,7 +5,7 @@ import { draftMode } from "next/headers"
 import { Headline } from "@/components/layout/headline"
 import { getCachedBlogPosts, getCachedPageContent, getCachedPages } from "@/lib/cms/fetchers"
 import { notFound } from "next/navigation"
-import { businessIdeas, pageTitle } from "@/content/config"
+import { pageTitle } from "@/content/config"
 import { GdprIframe } from "@/components/gdpr-iframe"
 import { getCollections } from "@/content/collections"
 import { BlogPostList } from "@/components/blog-post-list"
@@ -13,7 +13,6 @@ import { formatDate } from "@/lib/date"
 import { Link } from "@/components/layout/link"
 import "./page.css"
 import { fetchBlogPosts } from "@/lib/cms/fetch"
-import bussinessIdeasOgImage from "@/app/guides/business-ideas/[slug]/opengraph-image.png"
 
 export async function generateStaticParams() {
   return (await getCachedPages()).map((p) => ({ slug: p.slug }))
@@ -123,7 +122,7 @@ const Newsletter = () => {
         src="https://fabianrosenthal.substack.com/embed"
         className="h-[500px] w-full border-0 bg-none"
         scrolling="no"
-        title="Substack newsletter"
+        title="Substack Newsletter"
       />
     </GdprIframe>
   )

--- a/src/app/api/cms/draft/route.ts
+++ b/src/app/api/cms/draft/route.ts
@@ -4,7 +4,7 @@ import { APIResponseError, isFullPage } from "@notionhq/client"
 import { propsPlainTexts } from "@xennis/react-notion-cms-fetch"
 
 import { fetchPage } from "@/lib/cms/fetch"
-import { blogPagePost, businessIdeasPage, slugPage } from "@/content/config"
+import { blogPagePost, slugPage } from "@/content/config"
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url)
@@ -53,8 +53,6 @@ const canonicalPathname = ({ slug, parentDbId }: { slug: string | null; parentDb
   switch (parentDbId) {
     case "0decc798-b1fd-4d76-87c8-2ffc8f5e5fa4":
       return blogPagePost(slug)
-    case process.env.NOTION_GUIDE_BUSINESS_IDEAS_DB_ID!:
-      return businessIdeasPage(slug)
     case process.env.NOTION_PAGES_DB_ID!:
       return slugPage(slug)
   }

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -54,18 +54,18 @@ const BlogMeta = ({ post }: { post: BlogPost }) => {
   return (
     <div className="text-onbackground-600 flex flex-col gap-y-3 text-sm">
       <div className="flex flex-row space-x-2">
-        <CalendarIcon title="Publish date" aria-hidden={true} className="h-5 w-5" />
+        <CalendarIcon title="Veröffentlichungsdatum" aria-hidden={true} className="h-5 w-5" />
         <div>
-          <span className="sr-only">Publish date: </span>
+          <span className="sr-only">Veröffentlichungsdatum: </span>
           {formatDate(post.publishDate)}
           <span className="px-2">·</span>
-          Published in <Link href={blogPage}>Blog</Link>
+          Veröffentlicht im <Link href={blogPage}>Blog</Link>
         </div>
       </div>
       <div className="flex flex-row space-x-2">
-        <TagIcon title="Topics" aria-hidden={true} className="h-5 w-5" />
+        <TagIcon title="Themen" aria-hidden={true} className="h-5 w-5" />
         <div>
-          <span className="sr-only">Topics: </span>
+          <span className="sr-only">Themen: </span>
           <BlogTagList tags={post.tags} />
         </div>
       </div>
@@ -118,14 +118,14 @@ export default async function BlogSlugPage(props: { params: Promise<{ slug: stri
       {isEnabled && (
         <div className="mb-10 rounded-lg bg-red-300 p-4 text-center">
           <div className="text-lg">
-            Draft Mode (
+            Entwurfsmodus (
             <NextLink className="underline hover:no-underline" href={apiDisableDraft} target="_blank">
-              disable
+              deaktivieren
             </NextLink>
             )
           </div>
           <div>
-            Page:{" "}
+            Seite:{" "}
             <a
               className="underline hover:no-underline"
               href={`https://www.notion.so/${post.notionId.replaceAll("-", "")}`}
@@ -146,7 +146,7 @@ export default async function BlogSlugPage(props: { params: Promise<{ slug: stri
         <div className="relative mx-auto my-8 aspect-[1.91/1] w-full sm:my-10 md:max-w-[825px]">
           <NextImage
             src={post.ogImage}
-            alt="Blog image"
+            alt="Blog-Bild"
             fill
             className="rounded-lg shadow-md sm:rounded-xl sm:shadow-lg"
             quality={100}

--- a/src/app/blog/tag/[tag]/page.tsx
+++ b/src/app/blog/tag/[tag]/page.tsx
@@ -19,7 +19,7 @@ export async function generateMetadata(props: { params: Promise<{ tag: string }>
   if (!tag) {
     return null
   }
-  const description = `All blog articles with the tag ${tag.label}.`
+  const description = `Alle Blog-Artikel mit dem Tag ${tag.label}.`
   return {
     alternates: {
       canonical: tag.canonical,
@@ -60,7 +60,7 @@ export default async function TagPage(props: { params: Promise<{ tag: string }> 
 
   return (
     <div className="mx-auto max-w-(--breakpoint-md)">
-      <Headline subtitle="Blog articles with this tag.">Topic: {tagName}</Headline>
+      <Headline subtitle="Blog-Artikel mit diesem Tag.">Thema: {tagName}</Headline>
       <BlogPostList posts={postsWithTag} />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
     </div>

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -5,7 +5,7 @@ import { homePage } from "@/content/config"
 import { Headline } from "@/components/layout/headline"
 
 export const metadata: Metadata = {
-  title: "Not Found",
+  title: "Nicht gefunden",
   robots: {
     index: false,
   },
@@ -14,9 +14,9 @@ export const metadata: Metadata = {
 export default function NotFound() {
   return (
     <div className="max-width-regular">
-      <Headline>Page Not Found</Headline>
+      <Headline>Seite nicht gefunden</Headline>
       <p>
-        This page could not be found. Return to <NextLink href={homePage}>Home</NextLink>.
+        Diese Seite konnte nicht gefunden werden. Zurück zur <NextLink href={homePage}>Startseite</NextLink>.
       </p>
     </div>
   )

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -25,13 +25,13 @@ export default function HomePage() {
           "@type": "Person",
           name: "Fabian Rosenthal",
           image: `https://${host}${profileLargeImage}`,
-          jobTitle: "Software Engineer",
+          jobTitle: "Softwareentwickler",
           url: `https://${host}`,
           sameAs: collections.socialLinks.map((l) => l.href),
         }}
       />
       <div className="mx-auto max-w-(--breakpoint-md) pt-14 sm:pt-16">
-        <Headline2>Short Bio</Headline2>
+        <Headline2>Kurzbiografie</Headline2>
         <div className="flex flex-col py-2">
           {collections.shortBio.map((s, index) => {
             return (
@@ -45,12 +45,12 @@ export default function HomePage() {
           })}
         </div>
         <div className="pt-2.5">
-          I work four days a week at{" "}
+          Ich arbeite vier Tage pro Woche bei{" "}
           <Link href="https://cc.systems/en/" target="_blank">
             cc.systems
-          </Link>
-          , building software applications for clients. Alongside, I run a solo business creating apps and SaaS
-          products.
+          </Link>{" "}
+          und entwickle dort Software-Anwendungen für Kunden. Daneben führe ich ein Solo-Unternehmen und entwickle Apps
+          und SaaS-Produkte.
         </div>
         <Projects />
       </div>

--- a/src/components/author-header.tsx
+++ b/src/components/author-header.tsx
@@ -17,14 +17,14 @@ export function AuthorHeader({
       <div className="md:flex md:items-center md:justify-center md:space-x-16">
         <div className="pb-8 text-center md:pb-0">
           <h1 className="text-4xl font-semibold tracking-tight sm:text-5xl">
-            Ahoy, I&apos;m Fabian
+            Ahoi, ich bin Fabian
             <Dot />
           </h1>
           <div>
-            I <span aria-hidden={true}>🖤</span>
-            <span className="sr-only">love</span> software development & sports.
+            Ich <span aria-hidden={true}>🖤</span>
+            <span className="sr-only">liebe</span> Softwareentwicklung & Sport.
           </div>
-          <ul aria-label="Links to social media profiles" className="flex justify-center space-x-4 pt-8">
+          <ul aria-label="Links zu Social-Media-Profilen" className="flex justify-center space-x-4 pt-8">
             {socialLinks.map((l, index) => (
               <li key={index}>
                 <SocialLink {...l} className="duration-500 group-hover:scale-110" />
@@ -38,7 +38,7 @@ export function AuthorHeader({
           height={350}
           width={350}
           src={profileLargeImage}
-          alt="Profile picture of Fabian"
+          alt="Profilbild von Fabian"
           unoptimized
           priority
         />

--- a/src/components/blog-post-list.tsx
+++ b/src/components/blog-post-list.tsx
@@ -43,15 +43,21 @@ const BlogPostCard = ({ post }: { post: BlogPost }) => {
         <div>
           <div className="relative aspect-[1.91/1] w-full sm:w-[267px]">
             {post.ogImage && (
-              <NextImage src={post.ogImage} alt="Post image" className="rounded-md sm:rounded-lg" fill quality={100} />
+              <NextImage
+                src={post.ogImage}
+                alt="Beitragsbild"
+                className="rounded-md sm:rounded-lg"
+                fill
+                quality={100}
+              />
             )}
           </div>
         </div>
       </NextLink>
       <div className="gap-3 pt-4 text-sm text-gray-600 md:flex md:flex-row">
         <div className="flex gap-1">
-          <CalendarIcon title="Published" aria-hidden={true} className="h-5 w-5" />
-          <span className="sr-only">Published: </span>
+          <CalendarIcon title="Veröffentlicht" aria-hidden={true} className="h-5 w-5" />
+          <span className="sr-only">Veröffentlicht: </span>
           <span>{formatDate(post.publishDate)}</span>
         </div>
         <div className="flex gap-1.5 pt-3 md:pt-0">

--- a/src/components/gdpr-iframe.tsx
+++ b/src/components/gdpr-iframe.tsx
@@ -72,7 +72,7 @@ export function GdprIframe({
           className="bg-onbackground-900 rounded-sm px-3 py-1.5 font-semibold text-white shadow-sm"
           onClick={onClick}
         >
-          Load external content
+          Externen Inhalt laden
         </button>
       </div>
     </div>

--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -11,7 +11,7 @@ export function Footer({
 }) {
   return (
     <footer className="pxcontent border-t-[1px] border-gray-100 py-6 md:flex md:justify-between">
-      <ul aria-label="Links to social media profiles" className="flex items-center space-x-4">
+      <ul aria-label="Links zu Social-Media-Profilen" className="flex items-center space-x-4">
         {socialLinks.map((l, index) => (
           <li key={index}>
             <SocialLink {...l} className="group-hover:grayscale" />

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -8,11 +8,11 @@ import { SocialLink } from "@/components/social-links"
 function Logo({ homeHref }: { homeHref: string }) {
   return (
     <div>
-      <NextLink title="Home" aria-label="Home" href={homeHref} className="group flex items-center">
+      <NextLink title="Startseite" aria-label="Startseite" href={homeHref} className="group flex items-center">
         <NextImage
           className="rounded-sm"
           src={authorImage}
-          alt="Profile picture of Fabian"
+          alt="Profilbild von Fabian"
           width={75}
           height={75}
           quality={100}
@@ -20,7 +20,7 @@ function Logo({ homeHref }: { homeHref: string }) {
         <div className="ps-3">
           <span className="group-hover:text-primary-500 text-xl font-semibold tracking-tight">{pageTitle}</span>
           <br />
-          <span>Software Engineer</span>
+          <span>Softwareentwickler</span>
         </div>
       </NextLink>
     </div>
@@ -74,7 +74,7 @@ export function Header({
 const HeroButton = () => {
   return (
     <div className="border-onbackground-200 border-s-2 ps-6 hover:grayscale md:ps-3">
-      <SocialLink label="Subscribe" href={youtubeSubscribeLink} imageSrc={youtubeIcon} />
+      <SocialLink label="Abonnieren" href={youtubeSubscribeLink} imageSrc={youtubeIcon} />
     </div>
   )
 }

--- a/src/components/projects.tsx
+++ b/src/components/projects.tsx
@@ -6,22 +6,22 @@ const projects = [
     name: "More Than Kudos",
     tags: ["Flutter", "Firebase", "Strava", "GCP"],
     shortDescription:
-      "Turn your workouts into motivation! Track your progress with Strava and enjoy a personal reward when you reach your goals.",
-    status: "in progress",
+      "Verwandle deine Workouts in Motivation! Verfolge deinen Fortschritt mit Strava und freue dich über eine persönliche Belohnung, wenn du deine Ziele erreichst.",
+    status: "in Arbeit",
   },
   {
     name: "Cookli",
     href: "https://cookli.app",
     tags: ["Next.js", "PWA", "GCP"],
     shortDescription:
-      "Create a personalized digital cookbook with your friends and partners! Collect, organize, and share your favorite recipes in one place.",
+      "Erstelle gemeinsam mit Freunden und Partnern ein personalisiertes digitales Kochbuch! Sammle, organisiere und teile deine Lieblingsrezepte an einem Ort.",
     status: "active",
   },
   {
     name: "Green Walking: Walk & Hike Map",
     href: "https://play.google.com/store/apps/details?id=org.xennis.apps.green_walking",
     tags: ["AndroidApp", "Flutter"],
-    shortDescription: "The map shows all kinds of trails for walking and hiking.",
+    shortDescription: "Die Karte zeigt verschiedenste Wege zum Spazieren und Wandern.",
     status: "active",
   },
   // {
@@ -35,7 +35,7 @@ const projects = [
     name: "EpiDoc Parser",
     href: "https://xennis.github.io/epidoc-parser/",
     tags: ["PythonLibrary", "Epigraphy"],
-    shortDescription: "Python parser for EpiDoc (epigraphic documents in TEI XML).",
+    shortDescription: "Python-Parser für EpiDoc (epigraphische Dokumente in TEI XML).",
     status: "active",
   },
 ]
@@ -70,7 +70,7 @@ function ProjectItem({ project }: { project: (typeof projects)[number] }) {
 export function Projects() {
   return (
     <div className="pt-10 md:pt-12">
-      <Headline2>Current Projects</Headline2>
+      <Headline2>Aktuelle Projekte</Headline2>
       <ul className="ms-6 list-outside list-disc py-1 leading-7">
         {projects.map((p, index) => (
           <li key={index} className="pt-2">

--- a/src/content/collections.ts
+++ b/src/content/collections.ts
@@ -36,31 +36,34 @@ const socialLinks = [
 
 const collections = {
   footer: {
-    navLinks: [{ label: "Legal Notice", href: legalPage }],
+    navLinks: [{ label: "Impressum", href: legalPage }],
   },
   gdprIframe: {
     calcom: {
-      firstLine: "I use the external calendar from Cal.com for scheduling calls.",
-      secondLine: "By clicking the button, you consent to the use of cookies by Cal.com.",
-      gdprLinkPrefix: "For details, please see their",
-      gdprLinkLabel: "privacy policy",
+      firstLine: "Ich nutze den externen Kalender von Cal.com, um Telefonate zu vereinbaren.",
+      secondLine: "Mit einem Klick auf den Button stimmst du der Verwendung von Cookies durch Cal.com zu.",
+      gdprLinkPrefix: "Details findest du in deren",
+      gdprLinkLabel: "Datenschutzerklärung",
       gdprLinkHref: "https://cal.com/privacy",
     },
     substack: {
-      firstLine: "I use the external service Substack for my newsletter.",
-      secondLine: "By clicking the button, you consent to the use of cookies by Substack.",
-      gdprLinkPrefix: "For details, please see their",
-      gdprLinkLabel: "privacy policy",
+      firstLine: "Ich nutze den externen Dienst Substack für meinen Newsletter.",
+      secondLine: "Mit einem Klick auf den Button stimmst du der Verwendung von Cookies durch Substack zu.",
+      gdprLinkPrefix: "Details findest du in deren",
+      gdprLinkLabel: "Datenschutzerklärung",
       gdprLinkHref: "https://substack.com/privacy",
     },
   },
   header: {
-    navLinks: [{ label: "Articles", href: blogPage }],
+    navLinks: [{ label: "Artikel", href: blogPage }],
   },
   shortBio: [
-    { emoji: "👨‍💻", text: "Software Engineer by profession" },
-    { emoji: "🏃", text: "Athlete by hobby" },
-    { emoji: "🎯", text: "Current mission: Building apps for myself to live healthier and get fitter" },
+    { emoji: "👨‍💻", text: "Softwareentwickler von Beruf" },
+    { emoji: "🏃", text: "Sportler aus Leidenschaft" },
+    {
+      emoji: "🎯",
+      text: "Aktuelle Mission: Apps für mich selbst entwickeln, um gesünder zu leben und fitter zu werden",
+    },
   ],
   socialLinks: socialLinks,
 }

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -6,18 +6,16 @@ export const slugPage = (slug: string) => `/${slug}`
 export const blogPage = "/blog"
 export const blogPagePost = (slug: string) => `/blog/${slug}`
 export const blogTagPage = (tag: string) => `/blog/tag/${tag}`
-export const businessIdeas = "/guides/business-ideas"
-export const businessIdeasPage = (slug: string) => `/guides/business-ideas/${slug}`
 export const homePage = "/"
-export const legalPage = "/legal"
+export const legalPage = "/impressum"
 export const newsletterPage = "/newsletter"
 export const apiDisableDraft = "/api/cms/disable-draft"
 
-export const locale = "en"
+export const locale = "de"
 export const brandColor = "#10b981"
 
 export const pageTitle = "Fabian Rosenthal"
 export const pageDescription =
-  "Software Developer, Indie Hacker & Creator. Building large applications & micro SaaS. Sharing my knowledge on building software products."
+  "Softwareentwickler, Indie Hacker & Creator. Ich entwickle große Anwendungen & Micro SaaS. Hier teile ich mein Wissen über die Entwicklung von Softwareprodukten."
 
 export const youtubeSubscribeLink = "https://youtube.com/@fabian.rosenthal?sub_confirmation=1"

--- a/src/lib/cms/blog-posts.ts
+++ b/src/lib/cms/blog-posts.ts
@@ -63,7 +63,7 @@ const propsFirstInternalFilesUrl = (properties: PageObjectResponse["properties"]
 export const tagToString = (tag: Tag) => {
   switch (tag) {
     case "accessibility":
-      return "Accessibility"
+      return "Barrierefreiheit"
     case "frontend":
       return "Frontend"
     case "nextjs":


### PR DESCRIPTION
- Set locale to 'de' (auto-applies <html lang> and date formatting)
- Translate all UI strings, aria-labels, alt text, JSON-LD, metadata, GDPR banners, project descriptions, and draft-mode UI to German (du)
- Rename legalPage slug from /legal to /impressum
- Remove unused guides/business-ideas feature (constants, draft route branch, and dead import)